### PR TITLE
Update the get to fix issues with spaces in the metric names

### DIFF
--- a/application/controller/api.php
+++ b/application/controller/api.php
@@ -234,11 +234,11 @@ class Api_Controller extends System_Controller  {
           foreach( $this->data->DS as $value){
             if ( isRegex($perflabel) ){
               if ( preg_match( $perflabel, arr_get($value, "LABEL" ) ) ){
-                $perflabels[] =  arr_get($value, "LABEL" );
+                $perflabels[] =  arr_get($value, "NAME" );
               }
             }else {
               if ( $perflabel == arr_get($value, "LABEL" ) ){
-                $perflabels[] = arr_get($value, "LABEL" );
+                $perflabels[] = arr_get($value, "NAME" );
               }
             }
           }


### PR DESCRIPTION
Looks like there is an issue when requesting data that has a space in it since it is using the wrong lookup.  Normally this isn't an issue since the label and the name are the same.