### PR TITLE
make .pnp-internal work again

### DIFF
--- a/application/controller/api.php
+++ b/application/controller/api.php
@@ -198,7 +198,7 @@ class Api_Controller extends System_Controller  {
         $service = $service['name'];
         try {
           // read XML file
-          $this->data->readXML($host, $service);
+          $this->data->readXML(($host == "pnp-internal" ? ".pnp-internal" : $host), $service);
         } catch (Kohana_Exception $e) {
           $data['error'] = "$e";
           return_json($data, 901);
@@ -225,7 +225,7 @@ class Api_Controller extends System_Controller  {
 
         foreach ( $perflabels as $tmp_perflabel){
           try {
-            $this->data->buildXport($host, $service);
+            $this->data->buildXport($host == "pnp-internal" ? ".pnp-internal" : $host, $service);
             $xml = $this->rrdtool->doXport($this->data->XPORT);
           } catch (Kohana_Exception $e) {
             $data['error'] = "$e";

--- a/application/controller/api.php
+++ b/application/controller/api.php
@@ -114,7 +114,7 @@ class Api_Controller extends System_Controller  {
     foreach($services as $service){
       try {
         // read XML file
-        $this->data->readXML($service['hostname'], $service['name']);
+        $this->data->readXML($service['hostname'] == "pnp-internal" ? ".pnp-internal" : $service['hostname'], $service['name']);
       } catch (Kohana_Exception $e) {
         $data['error'] = "$e";
         return_json($data, 901);
@@ -365,6 +365,9 @@ function getHosts($data, $query = false) {
     } else {
       $result[] = $host['name'];
     }
+  }
+  if ($query !== false && $query == ".pnp-internal") {
+    $result[] = ".pnp-internal";
   }
   return($result);
 }


### PR DESCRIPTION
Seems like the internal name of ".pnp-internal" is without a leading dot, which leads to some file-not-found exceptions. So adjust it whereever required.